### PR TITLE
Add ChatLayout, SearchBar, FlowerInfoCard, and ImageUpload changes

### DIFF
--- a/frontend/src/components/ChatLayout.tsx
+++ b/frontend/src/components/ChatLayout.tsx
@@ -1,112 +1,176 @@
-import { useState, useRef } from "react";
+//useState -> mahe component state like the messages and pat convo
+//useRef -> create references to DOM elements like file input and messages end for scrolling
+//useEffect -> perform side effects like auto scrolling to bottom when new message is added
+import { useState, useRef, useEffect } from "react";
+//import child compontnts made earlier and mock data
 import SearchBar from "./SearchBar";
 import FlowerInfoCard from "./FlowerInfoCard";
 import { mockFlowers } from "../data/mockData";
 
+// represent a single message in the conversation, flow and optional image
+interface ConversationCard {
+  flower: typeof mockFlowers[0];
+  imageUrl?: string | null;
+}
+
+// represent a past conversation with id, title and array of messages
+interface PastConversation {
+  id: number;
+  title: string;
+  messages: ConversationCard[];
+}
+
+// state and references for chat layout component
 export default function ChatLayout() {
-  const [selectedFlower, setSelectedFlower] = useState<typeof mockFlowers[0] | null>(null);
-  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  // holds the messages in the current conversation
+  const [currentConversation, setCurrentConversation] = useState<ConversationCard[]>([]);
+  // store the previous conversations for the sidebar
+  const [pastConversations, setPastConversations] = useState<PastConversation[]>([]);
+  // unique id for each conversation
+  const [conversationId, setConversationId] = useState(1);
 
+  // references to the hidden file input afor image upload
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // referece to the end of the messages list for auto scrolling
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
+  // Scroll to bottom when new message appears
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [currentConversation]);
+
+  // handle text search
+  // searched mockflowers by name for a exact match, it is case sensitive
+  // when found, add to current conversation
   const handleSearch = (query: string) => {
     const result = mockFlowers.find(
       (f) => f.name.toLowerCase() === query.toLowerCase()
     );
-    setSelectedFlower(result || null);
+    if (result) {
+      setCurrentConversation((prev) => [...prev, { flower: result }]);
+    }
   };
 
+  // handle image upload
+  //when a file is selected, create a URL for it and add to current conversation with a mock prediction
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const url = URL.createObjectURL(file);
-      setUploadedImage(url);
-      // Mock: set a flower match
-      setSelectedFlower(mockFlowers[1]); // e.g., Tulip
+      const matchedFlower = mockFlowers[1]; // Mock prediction (Tulip)
+      setCurrentConversation((prev) => [
+        ...prev,
+        { flower: matchedFlower, imageUrl: url },
+      ]);
     }
   };
 
+  // handle New Chat
+  // saves current conversation to past conversations with title of the first flower, future can change to query
+  // wont add if empty then wont add
+  // resets current conversation to start a new chat
+  const handleNewChat = () => {
+    if (currentConversation.length > 0) {
+      const firstFlower = currentConversation[0]?.flower?.name || "Untitled Chat";
+      const newEntry: PastConversation = {
+        id: conversationId,
+        title: firstFlower,
+        messages: currentConversation,
+      };
+
+      setPastConversations((prev) => [...prev, newEntry]);
+      setConversationId((id) => id + 1);
+    }
+
+    setCurrentConversation([]); // reset chat
+  };
+
   return (
+    /* JSX Lauout */
     <div className="h-screen w-screen flex">
       {/* Sidebar */}
-      <div className="w-64 bg-gray-100 p-4 overflow-y-auto border-r border-gray-300">
-        {/* New Chat Button */}
-  <button
-    onClick={() => {
-      setSelectedFlower(null);
-      setUploadedImage(null);
-    }}
-    className="w-full mb-4 px-4 py-2 text-white rounded-lg "
-  >
-    New Chat
-  </button>
-
-        <h2 className="font-bold text-lg mb-4">Past Conversations</h2>
-        <table className="w-full table-auto border-collapse">
-          <thead>
-            <tr className="bg-gray-200">
-              <th className="p-2 border-b">#</th>
-              <th className="p-2 border-b">Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="hover:bg-gray-50">
-              <td className="p-2 border-b text-center">1</td>
-              <td className="p-2 border-b">Boquet for valentines?</td>
-            </tr>
-            <tr className="hover:bg-gray-50">
-              <td className="p-2 border-b text-center">2</td>
-              <td className="p-2 border-b">What is the meaning of tuplips?</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      {/* Right main area */}
-<div className="flex-1 flex flex-col">
-  {/* Results area */}
-  <div className="flex-1 overflow-y-auto p-4 gap-4 flex flex-col">
-    {selectedFlower ? (
-      <div className="flex gap-4">
-        {/* Left: card + mock prediction */}
-        <div className="flex flex-col space-y-2">
-          <FlowerInfoCard flower={selectedFlower} />
-            {uploadedImage && (
-            <p className="text-gray-600 text-sm">
-              Mock prediction: <strong>{selectedFlower.name} (92%)</strong>
-            </p>
+      {/* has new chat button, past conversations list and account button at bottom */}
+      <div className="w-64 bg-gray-100 p-4 flex flex-col border-r border-gray-300">
+        {/* Top Section (New Chat + Past Conversations) */}
+        <div className="flex-1 overflow-y-auto">
+          <button
+            onClick={handleNewChat}
+            className="w-full mb-4 px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600"
+          >
+            New Chat
+          </button>
+          {/* Past Conversations List */}
+          {/* maps padt conversations to a table, click on a row to load that conversation */}
+          <h2 className="font-bold text-lg mb-4">Past Conversations</h2>
+          {pastConversations.length > 0 ? (
+            <table className="w-full table-auto border-collapse">
+              <thead>
+                <tr className="bg-gray-200">
+                  <th className="p-2 border-b w-10">#</th>
+                  <th className="p-2 border-b text-left">Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pastConversations.map((chat) => (
+                  <tr
+                    key={chat.id}
+                    className="hover:bg-gray-50 cursor-pointer"
+                    onClick={() => setCurrentConversation(chat.messages)}
+                  >
+                    <td className="p-2 border-b text-center">{chat.id}</td>
+                    <td className="p-2 border-b truncate">{chat.title}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="text-gray-500 text-sm">No past conversations yet.</p>
           )}
         </div>
 
-        {/* Right: uploaded image */}
-        {uploadedImage && (
-          <div className="flex-shrink-0 w-20 h-20">
-            <img
-              src={uploadedImage}
-              alt="Uploaded flower"
-                            className="rounded-lg shadow w-full h-full object-contain"
-            />
-          </div>
-        )}
+        {/* Bottom Account Button */}
+        <div className="border-t pt-3 mt-3">
+          <button
+            className="w-full py-2 rounded-lg font-medium "
+          >
+            Account Details
+          </button>
+        </div>
       </div>
-    ) : (
-      <p className="text-gray-500">
-        Search or upload an image to see results.
-      </p>
-    )}
-  </div>
 
-        {/* Bottom pinned bar */}
+      {/* Main Chat Area */}
+      <div className="flex-1 flex flex-col bg-gray-50">
+        {/* Scrollable Chat Messages */}
+        {/* loops current conversation messages to display each flower info card */
+        /* renders flower info card component for each message in the current conversation, empty shows place holder text */}
+        <div className="flex-1 overflow-y-auto p-4 flex flex-col space-y-4">
+          {currentConversation.length > 0 ? (
+            currentConversation.map((msg, i) => (
+              <FlowerInfoCard key={i} flower={msg.flower} imageUrl={msg.imageUrl} />
+            ))
+          ) : (
+            <p className="text-gray-500 text-center mt-10">
+              Search or upload an image to start a conversation.
+            </p>
+          )}
+          {/*ensures auto scroll to bottom */}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Bottom Input Bar */}
         <div className="flex w-full border-t bg-white p-4 gap-2">
           <div className="flex-1">
+            {/* triggers handlesearch in parent component */}
             <SearchBar onSearch={handleSearch} />
           </div>
+          {/* upload button that triggers hidden file input */}
           <button
             onClick={() => fileInputRef.current?.click()}
             className="px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600"
           >
             Upload
           </button>
+          {/* hidden file input for image upload, handles actual file selection */}
           <input
             type="file"
             accept="image/*"

--- a/frontend/src/components/FlowerInfoCard.tsx
+++ b/frontend/src/components/FlowerInfoCard.tsx
@@ -1,3 +1,4 @@
+//info prestend 
 interface Flower {
   name: string;
   scientificName: string;
@@ -6,14 +7,52 @@ interface Flower {
   llmText: string;
 }
 
-export default function FlowerInfoCard({ flower }: { flower: Flower }) {
+// Props for FlowerInfoCard component, including optional imageUrl
+interface FlowerInfoCardProps {
+  flower: Flower;
+  imageUrl?: string | null;
+}
+
+// FlowerInfoCard react functional component to display flower details and optional image
+// uses object destructuring to extract flower and imageUrl from props
+export default function FlowerInfoCard({ flower, imageUrl }: FlowerInfoCardProps) {
   return (
-    <div className="max-w-md p-4 m-4 border rounded-2xl shadow">
+    // card has card limit to medium size, padding, margin, border, rounded corners, shadow, white background
+    // these are tailwind css classes
+    <div className="max-w-md p-4 m-4 border rounded-2xl shadow bg-white">
+      {/* Header */}
+      {/*flowe name is bold and large*/}
       <h2 className="text-2xl font-bold">{flower.name}</h2>
+      {/* its scientific name is italic and gray*/}
       <p className="italic text-gray-600">{flower.scientificName}</p>
-      <p className="mt-2"><strong>Symbolism:</strong> {flower.symbolism}</p>
-      <p><strong>Care:</strong> {flower.care}</p>
-      <p className="mt-3 text-pink-700">{flower.llmText}</p>
+
+      {/* Optional uploaded image and mock prediction */}
+      {imageUrl && (
+        /* margin top, flex column, center items */
+        /* margin puts space between heading and image, and the then the flex and layout gives a vertical layour centered horizontally */
+        <div className="mt-3 flex flex-col items-center">
+          {/* displays the image */}
+          <img
+            src={imageUrl}
+            alt="Uploaded flower"
+            /* this limits the image size when they are too large*/
+            /* also again rounded corners and a shaow */
+            className="max-w-[250px] max-h-[250px] object-contain rounded-lg shadow"
+          />
+          {/* mock prediction text below image, gray and small */}
+          <p className="text-gray-600 text-sm mt-2">
+            Mock prediction: <strong>{flower.name} (92%)</strong>
+          </p>
+        </div>
+      )}
+
+      {/* Text content */}
+      {/* margin for top spacing, and space-y-1 adds vertical spacing between lines */}
+      <div className="mt-3 space-y-1">
+        <p><strong>Symbolism:</strong> {flower.symbolism}</p>
+        <p><strong>Care:</strong> {flower.care}</p>
+        <p className="mt-3 text-pink-700">{flower.llmText}</p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,26 +1,46 @@
+// this holds the image upload component
 import { useRef } from "react";
 
+// Props for ImageUpload component
+// expects one prop, onUpload takes the string which would be the image url, and return nothing if not provided
 interface ImageUploadProps {
   onUpload: (imageUrl: string) => void;
 }
 
+// react functional component for image upload
+// uses object destructuring to extract onUpload from props
 export default function ImageUpload({ onUpload }: ImageUploadProps) {
+  //ref to the hidden file input element
+  //useRef tells typescript that reference will point to a input element of type file, but starts as null before element is rendered to open fiile dialog programatically from another component or button
+  //inputRef will give ascces to the real HTML input element in the DOM
   const inputRef = useRef<HTMLInputElement>(null);
 
+  //this is when a file is selected
+  // ChangeEvent wrapper around the native event for type safety
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // get the first file from the input element of all selected files
     const file = e.target.files?.[0];
     if (file) {
+      // URL.createObjectURL creates a temporary URL for the file object that the browser uses to preview files, doesnt upload the file to a server local only
       const url = URL.createObjectURL(file);
+      //passes URL to parent component via the onUpload callback prop
+      // parent can display, store in state, or send to a server
       onUpload(url);
     }
   };
 
   return (
+    // hidden file input element
     <input
+      // connects the ref to this input element so can access it programmatically
       ref={inputRef}
+      // tells browser its a file upload input
       type="file"
+      // only image files can be selected
       accept="image/*"
+      // hidden from view, we will trigger it with a button elsewhere
       className="hidden"
+      // when a file is selected, call handleFileChange
       onChange={handleFileChange}
     />
   );

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,23 +1,59 @@
+// add state to functional components
+//here will store the current typed text in the search bar
 import { useState } from "react";
 
+// Props for SearchBar component
+// onSearch is a function that takes a string and returns void
+// send to parent component when user searches
 interface SearchBarProps {
   onSearch: (query: string) => void;
 }
 
+//declare a functional component called SearchBar
+// uses object destructuring to extract onSearch from props
 export default function SearchBar({ onSearch }: SearchBarProps) {
+  //state decleration
+  // query = current text typed
+  // setQuery = function to update the query state
+  // initial state is an empty string
   const [query, setQuery] = useState("");
 
+  // handle "Enter" key press to trigger search
+  // function runs when a key is pressed while the input is focused
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // that key is the enter key
+    if (e.key === "Enter") {
+      //calles on search with the typed query
+      onSearch(query);
+    }
+  };
+
+  // JSX to render the search bar
   return (
+    // flex container to hold input and button and stretch to full width and aligns input and button horizontally
     <div className="flex w-full">
+      {/* this is the input field */}
       <input
+        // standard text input field
         type="text"
+        // text when input is empty
         placeholder="Search for a flower..."
+        // controlled component, displayed value will come from query state
         value={query}
+        // update query state when user types
         onChange={(e) => setQuery(e.target.value)}
+        // lias to handle key presses
+        onKeyDown={handleKeyDown} 
+        // tailwind css classes for styling
+        // makes input take up all available space, padding, border, rounded left corners, gray border, focus styles
         className="flex-1 p-2 border rounded-l-lg border-gray-300 focus:outline-none focus:ring-2 focus:ring-pink-400"
       />
+      {/* this is the search button */}
       <button
+        // when clicked, calls onSearch with the current query
         onClick={() => onSearch(query)}
+        // tailwind css classes for styling
+        // padding, pink background, white text, rounded right corners, hover effect
         className="px-4 py-2 bg-pink-500 text-white rounded-r-lg hover:bg-pink-600"
       >
         Search


### PR DESCRIPTION
- Modified the code so the Image and mock prediction appear in the flowerinfo card
- made it so multiple cards can be part of the conversation, scrollable, and automatically scroll to the bottom when a new query is made
- The past conversation sidebar actually holds the past conversation, at the moment uses the first flower as the title
- An account button that isn't active at the moment
- And can use the enter key to do a word-based query